### PR TITLE
Fix issue #62

### DIFF
--- a/Source/Plugin.Badge.iOS/BadgedTabbedPageRenderer.cs
+++ b/Source/Plugin.Badge.iOS/BadgedTabbedPageRenderer.cs
@@ -129,7 +129,7 @@ namespace Plugin.Badge.iOS
         public bool CheckValidTabIndex(Page page, out int tabIndex)
         {
             tabIndex = Tabbed.Children.IndexOf(page);
-            return tabIndex < TabBar.Items.Length;
+            return tabIndex >= 0 && tabIndex < TabBar.Items.Length;
         }
 
         private async void OnTabAdded(object sender, ElementEventArgs e)

--- a/Source/Plugin.Badge.iOS/BadgedTabbedPageRenderer.cs
+++ b/Source/Plugin.Badge.iOS/BadgedTabbedPageRenderer.cs
@@ -129,6 +129,8 @@ namespace Plugin.Badge.iOS
         public bool CheckValidTabIndex(Page page, out int tabIndex)
         {
             tabIndex = Tabbed.Children.IndexOf(page);
+            if (tabIndex == -1 && page.Parent != null)
+                tabIndex = Tabbed.Children.IndexOf(page.Parent);
             return tabIndex >= 0 && tabIndex < TabBar.Items.Length;
         }
 


### PR DESCRIPTION
This PR contains fix of issue https://github.com/xabre/xamarin-forms-tab-badge/issues/62 suggested by @Phenek. 
It allows avoiding `IndexOutOfRange` exception. Besides, it solves cases when a page with attached `TabBadge.Badge*Property` lies within a parent, while it should not affect exising use cases.
