### PR TITLE
Update Plugin.Badge.UWP.xr.xml location in nuspec

### DIFF
--- a/.build/Plugin.Badge.nuspec
+++ b/.build/Plugin.Badge.nuspec
@@ -1,7 +1,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Plugin.Badge</id>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <title>Tab Badge for Xamarin.Forms</title>
     <authors>Adrian Seceleanu</authors>
     <owners>Adrian Seceleanu</owners>
@@ -14,6 +14,8 @@
     <tags>xamarin xamarin.forms badge tab tabbar monodroid Xamarin.iOS uwp uap android ios windows universal mac macos osx</tags>
     <iconUrl>https://raw.githubusercontent.com/xabre/xamarin-forms-tab-badge/master/icon_small.png</iconUrl>
     <releaseNotes>
+      [2.3.1]
+      - Update Plugin.Badge.UWP.xr.xml location in nuspec
       [2.3.0-pre.2]
       - #87: Update XF version in nuspec
       [2.3.0-pre.1]
@@ -85,8 +87,8 @@
     <file src="out\lib\ios\Plugin.Badge.*" target="lib\Xamarin.iOS10" />
     <!-- uap -->
     <file src="out\lib\uwp\Plugin.Badge.UWP\Plugin.Badge.*" target="lib\uap10.0" />
-    <file src="..\Source\Plugin.Badge.UWP\bin\Release\**\HeaderTemplate.*" target="lib\uap10.0\Plugin.Badge.UWP" />
-    <file src="..\Source\Plugin.Badge.UWP\bin\Release\**\Plugin.Badge.UWP.xr.xml" target="lib\uap10.0\Plugin.Badge.UWP" />
+    <file src="..\Source\Plugin.Badge.UWP\bin\Release\**\HeaderTemplate.*" target="lib\uap10.0" />
+    <file src="..\Source\Plugin.Badge.UWP\bin\Release\**\Plugin.Badge.UWP.xr.xml" target="lib\uap10.0" />
     <!-- mac -->
     <file src="out\lib\mac\Plugin.Badge.*" target="lib\xamarinmac20" />
     <!-- wpf -->


### PR DESCRIPTION
Fixes #94 

Error MSB3030: Could not copy the file "C:\Users\xxx\.nuget\packages\plugin.badge\2.3.0\lib\uap10.0\Plugin.Badge.UWP\Plugin.Badge.UWP.xr.xml" because it was not found. 