### PR TITLE
Fix IndexOutOfRangeException and update XF

### DIFF
--- a/Source/Plugin.Badge.Abstractions/Plugin.Badge.Abstractions.csproj
+++ b/Source/Plugin.Badge.Abstractions/Plugin.Badge.Abstractions.csproj
@@ -6,7 +6,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
 </Project>

--- a/Source/Plugin.Badge.Droid/BadgedTabbedPageRenderer.cs
+++ b/Source/Plugin.Badge.Droid/BadgedTabbedPageRenderer.cs
@@ -77,6 +77,11 @@ namespace Plugin.Badge.Droid
 
         private void AddTabBadge(int tabIndex)
         {
+            if (tabIndex == -1)
+            {
+                return;
+            }
+
             var page = Element.GetChildPageWithBadge(tabIndex);
 
             var placement = Element.OnThisPlatform().GetToolbarPlacement();

--- a/Source/Plugin.Badge.Droid/LegacyBadgedTabbedRenderer.cs
+++ b/Source/Plugin.Badge.Droid/LegacyBadgedTabbedRenderer.cs
@@ -84,6 +84,11 @@ namespace Plugin.Badge.Droid
 
         private void AddTabBadge(int tabIndex)
         {
+            if (tabIndex == -1)
+            {
+                return;
+            }
+
             if (!(_tabLinearLayout.GetChildAt(tabIndex) is ViewGroup view) || tabIndex >= Element.Children.Count)
             {
                 return;

--- a/Source/Plugin.Badge.Droid/Plugin.Badge.Droid.csproj
+++ b/Source/Plugin.Badge.Droid/Plugin.Badge.Droid.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Source/Plugin.Badge.Mac/BadgedTabbedPageRenderer.cs
+++ b/Source/Plugin.Badge.Mac/BadgedTabbedPageRenderer.cs
@@ -46,6 +46,11 @@ namespace Plugin.Badge.Mac
 
         protected virtual void AddTabBadge(int tabIndex)
         {
+            if (tabIndex == -1)
+            {
+                return;
+            }
+
             var segment = _segmentedControl.Subviews[tabIndex];
 
             var element = Tabbed.GetChildPageWithBadge(tabIndex);

--- a/Source/Plugin.Badge.Mac/Plugin.Badge.Mac.csproj
+++ b/Source/Plugin.Badge.Mac/Plugin.Badge.Mac.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />

--- a/Source/Plugin.Badge.Sample.Droid.Legacy/Plugin.Badge.Sample.Droid.Legacy.csproj
+++ b/Source/Plugin.Badge.Sample.Droid.Legacy/Plugin.Badge.Sample.Droid.Legacy.csproj
@@ -112,7 +112,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Source/Plugin.Badge.UWP/Plugin.Badge.UWP.csproj
+++ b/Source/Plugin.Badge.UWP/Plugin.Badge.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Plugin.Badge.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+	<TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -145,7 +145,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Source/Plugin.Badge.WPF/Plugin.Badge.WPF.csproj
+++ b/Source/Plugin.Badge.WPF/Plugin.Badge.WPF.csproj
@@ -98,10 +98,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.Platform.WPF">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/Plugin.Badge.iOS/BadgedTabbedPageRenderer.cs
+++ b/Source/Plugin.Badge.iOS/BadgedTabbedPageRenderer.cs
@@ -38,6 +38,11 @@ namespace Plugin.Badge.iOS
 
         private void AddTabBadge(int tabIndex)
         {
+            if (tabIndex == -1)
+            {
+                return;
+            }
+
             var element = Tabbed.GetChildPageWithBadge(tabIndex);
             element.PropertyChanged += OnTabbedPagePropertyChanged;
 

--- a/Source/Plugin.Badge.iOS/Plugin.Badge.iOS.csproj
+++ b/Source/Plugin.Badge.iOS/Plugin.Badge.iOS.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Source/Sample/Plugin.Badge.Sample.Droid/Plugin.Badge.Sample.Droid.csproj
+++ b/Source/Sample/Plugin.Badge.Sample.Droid/Plugin.Badge.Sample.Droid.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Source/Sample/Plugin.Badge.Sample.Mac/Plugin.Badge.Sample.Mac.csproj
+++ b/Source/Sample/Plugin.Badge.Sample.Mac/Plugin.Badge.Sample.Mac.csproj
@@ -78,7 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Sample/Plugin.Badge.Sample.UWP/Plugin.Badge.Sample.UWP.csproj
+++ b/Source/Sample/Plugin.Badge.Sample.UWP/Plugin.Badge.Sample.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Plugin.Badge.Sample.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -140,7 +140,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Source/Sample/Plugin.Badge.Sample.WPF/Plugin.Badge.Sample.WPF.csproj
+++ b/Source/Sample/Plugin.Badge.Sample.WPF/Plugin.Badge.Sample.WPF.csproj
@@ -114,10 +114,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.Platform.WPF">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/Sample/Plugin.Badge.Sample.iOS/Plugin.Badge.Sample.iOS.csproj
+++ b/Source/Sample/Plugin.Badge.Sample.iOS/Plugin.Badge.Sample.iOS.csproj
@@ -135,7 +135,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.356</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Source/Sample/Plugin.Badge.Sample/Plugin.Badge.Sample.csproj
+++ b/Source/Sample/Plugin.Badge.Sample/Plugin.Badge.Sample.csproj
@@ -11,7 +11,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Plugin.Badge.Abstractions\Plugin.Badge.Abstractions.csproj" />


### PR DESCRIPTION
When I started using your nuget package, I ran into a situation where the indexOf function can return a value of -1.
```
var tabIndex = Tabbed.Children.IndexOf(page);
```
This leads to a global application error.
I fixed this in a simple way and updated Xamarin Forms to the latest version. Everything works correctly.